### PR TITLE
No more skipped unit tests

### DIFF
--- a/src/RestrictedProcess.Tests/RestrictedProcess.Tests.csproj
+++ b/src/RestrictedProcess.Tests/RestrictedProcess.Tests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.StaFact" Version="0.3.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RestrictedProcess.Tests/RestrictedProcessSecurityTests.cs
+++ b/src/RestrictedProcess.Tests/RestrictedProcessSecurityTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace RestrictedProcess.Tests
 {
-    using System;
     using System.Diagnostics;
     using System.Linq;
     using System.Windows.Forms;
@@ -30,8 +29,7 @@ class Program
             Assert.True(result.Type == ProcessExecutionResultType.RunTimeError, "No exception is thrown!");
         }
 
-        [Fact(Skip = "System.Threading.ThreadStateException : Current thread must be set to single thread apartment (STA) mode before OLE calls can be made. Ensure that your Main function has STAThreadAttribute marked on it.")]
-        [STAThread]
+        [StaFact]
         public void RestrictedProcessShouldNotBeAbleToReadClipboard()
         {
             const string ReadClipboardSourceCode = @"using System;


### PR DESCRIPTION
We used to have `RestrictedProcessShouldNotBeAbleToReadClipboard` as skipped because xUnit doesn't support test methods that require running with `[STAThread]` but the NuGet package [`Xunit.StaFact`](https://github.com/AArnott/Xunit.StaFact/) provides this functionality and now we have all test methods running and passing.